### PR TITLE
Prevent animating initial position of some props

### DIFF
--- a/Catalog/Shared/CatalogViews/PropGroup.swift
+++ b/Catalog/Shared/CatalogViews/PropGroup.swift
@@ -87,7 +87,7 @@ struct PropGroupView: View {
         }
         .navigationTitle(group.name)
         .background(Color.background.edgesIgnoringSafeArea(.all))
-        .searchable(text: $queryString, prompt: "Search Components")
+        .searchable(text: $queryString, prompt: "Search Props")
     }
 
     func sampleCards(for samples: [PropSampleable]) -> some View {

--- a/Sources/Props/ProgressView/CircleBarProgressStyle.swift
+++ b/Sources/Props/ProgressView/CircleBarProgressStyle.swift
@@ -71,7 +71,7 @@ public struct CircleBarProgressStyle: ProgressViewStyle {
                         .overlay(label)
                         .offset(x: (proxy.size.width - diameter) * (fraction - 0.5))
                 }
-                .animation(.spring())
+                .animation(.spring(), value: fraction)
                 .padding(.vertical, 5)
                 .padding(.horizontal, 10)
             }

--- a/Sources/Props/ProgressView/DottedProgressStyle.swift
+++ b/Sources/Props/ProgressView/DottedProgressStyle.swift
@@ -60,7 +60,7 @@ public struct DottedProgressStyle: ProgressViewStyle {
                         .clipShape(ClipShape(pct: fraction))
                         .frame(height: height)
                 }
-                .animation(.spring())
+                .animation(.spring(), value: fraction)
             }
             .frame(height: height)
         }

--- a/Sources/Props/ProgressView/SquiggleProgressStyle.swift
+++ b/Sources/Props/ProgressView/SquiggleProgressStyle.swift
@@ -68,7 +68,7 @@ public struct SquiggleProgressStyle: ProgressViewStyle {
                         .frame(width: diameter, height: diameter)
                         .offset(x: (proxy.size.width - diameter) * (fraction - 0.5))
                 }
-                .animation(.spring())
+                .animation(.spring(), value: fraction)
                 .padding(.vertical, 5)
                 .padding(.horizontal, 10)
             }


### PR DESCRIPTION
Constrained the animations of some props to animate only on the animatable property to prevent the on-appear frame animations that look super broken.